### PR TITLE
Fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Parallax header view for react-native.
 ## Installation
 
 ```bash
-$ npm i react-native-header-parallax-view --save
+$ npm i react-native-parallax-header-view --save
 ```
 
 ## Demo


### PR DESCRIPTION
Package name was incorrect in README installation instructions, so if you were copy/pasting from the README, you would get this error: `error An unexpected error occurred: "https://registry.yarnpkg.com/react-native-header-parallax-view: Not found".`